### PR TITLE
Docker image for DL-Learner

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,7 @@ Documentation for DL-Learner:
  * manual: http://dl-learner.org/Resources/Documents/manual.pdf
  * components & config options: http://tiny.cc/dllearner-options
  * Javadoc: http://dl-learner.org/javadoc
+ * Docker: https://github.com/SmartDataAnalytics/DL-Learner/tree/develop/docker
 
 DL-Learner is Open Source and licensed under the GNU General Public License 3.
 (Copyright (c) 2007-2018, Jens Lehmann).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM maven:3.3.9-jdk-8
+
+MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>
+
+ENV DLLEARNER_VERSION=1.3.0
+
+RUN apt-get update && apt-get install -y openjfx wget
+#RUN git clone https://github.com/SmartDataAnalytics/DL-Learner.git /DL-Learner
+RUN wget https://github.com/SmartDataAnalytics/DL-Learner/releases/download/${DLLEARNER_VERSION}/dllearner-${DLLEARNER_VERSION}.zip
+#RUN cd /DL-Learner && git checkout develop
+#RUN cd /DL-Learner && mvn clean install -Dmaven.test.skip=true
+#RUN cd /dl-learner && ./buildRelease.sh
+#RUN cp interfaces/target/dl-learner.jar /dl-learner.jar
+
+RUN   unzip dllearner-${DLLEARNER_VERSION}.zip \
+      && mv dllearner-${DLLEARNER_VERSION} dllearner \
+      && rm dllearner-${DLLEARNER_VERSION}.zip
+      
+WORKDIR dllearner/
+
+#CMD ["java", "-Xmx2G", "-jar", "/dl-learner.jar", "-s", "/examples/father.conf"]
+CMD ["/bin/bash"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,11 +1,11 @@
 current_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 default:
-	docker build -t dl-learner .
+	docker build -t smartdataanalytics/dl-learner .
 
 run:
 	#docker run --rm --name dl-learner -v $(current_dir)results:/results -v $(current_dir)config:/config dl-learner
-	docker run -it dl-learner
+	docker run -it smartdataanalytics/dl-learner
 run-example:
 	#cp examples/father.conf.example examples/father.conf
-	docker run -it dl-learner bin/cli examples/father.conf
+	docker run -it smartdataanalytics/dl-learner bin/cli examples/father.conf

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,11 @@
+current_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+default:
+	docker build -t dl-learner .
+
+run:
+	#docker run --rm --name dl-learner -v $(current_dir)results:/results -v $(current_dir)config:/config dl-learner
+	docker run -it dl-learner
+run-example:
+	#cp examples/father.conf.example examples/father.conf
+	docker run -it dl-learner bin/cli examples/father.conf

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,6 @@
 # Docker image for DL-Learner
 This is a docker version of the DL-Learner! It is assambled from [the latest release](https://github.com/SmartDataAnalytics/DL-Learner/releases) of the framework.
+
 ## Getting started
 DL-Learner provide a `cli` interface which is the main command line interface to run learning tasks with the DL-Learner framework. The script takes a configuration file as argument and starts the configured learning algorithm. The DL-Learner release already contains a collection of examples. You can find them in the examples/ folder.
 
@@ -7,18 +8,21 @@ In order to run such intefrace via docker, use the following command:
 ```
 make run
 ```
-When the comand line intefrace it done you will be able to run the learning tasks offered by the DL-Learner framework. As it is described on the DL-Learner manual, you could run one of the examples by just doing 
+When the comand line intefrace it done you will be able to run the learning tasks offered by the DL-Learner framework. As it is described on the DL-Learner manual, you could run one of the examples by just doing: 
+
 ```sh
 bin/cli examples/father.conf
 ```
 
 The second executable in the bin/ folder is the `enrichment` script. This script infers new schema axioms based on the instance data of a given SPARQL endpoint. The enrichment can be performed for a particular resource (i.e. a class or a property) or for the whole dataset. To get suggestions for new schema axioms concerning the property <http://dbpedia.org/ontology/currency> you would run :
+
 ```sh
 bin/enrichment -e http://dbpedia.org/sparql -g http://dbpedia.org -r http://dbpedia.org/ontology/currency
 ```
 
 ### Executing Examples From CLI
 It is also possible to execute the examples from the command line. To run the father example you can type: 
+
 ```
 make run-example
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,26 @@
+# Docker image for DL-Learner
+This is a docker version of the DL-Learner! It is assambled from [the latest release](https://github.com/SmartDataAnalytics/DL-Learner/releases) of the framework.
+## Getting started
+DL-Learner provide a `cli` interface which is the main command line interface to run learning tasks with the DL-Learner framework. The script takes a configuration file as argument and starts the configured learning algorithm. The DL-Learner release already contains a collection of examples. You can find them in the examples/ folder.
+
+In order to run such intefrace via docker, use the following command:
+```
+make run
+```
+When the comand line intefrace it done you will be able to run the learning tasks offered by the DL-Learner framework. As it is described on the DL-Learner manual, you could run one of the examples by just doing 
+```sh
+bin/cli examples/father.conf
+```
+
+The second executable in the bin/ folder is the `enrichment` script. This script infers new schema axioms based on the instance data of a given SPARQL endpoint. The enrichment can be performed for a particular resource (i.e. a class or a property) or for the whole dataset. To get suggestions for new schema axioms concerning the property <http://dbpedia.org/ontology/currency> you would run :
+```sh
+bin/enrichment -e http://dbpedia.org/sparql -g http://dbpedia.org -r http://dbpedia.org/ontology/currency
+```
+
+### Executing Examples From CLI
+It is also possible to execute the examples from the command line. To run the father example you can type: 
+```
+make run-example
+```
+
+We recommend to read the [manual](http://dl-learner.org/Resources/Documents/manual.pdf) when using DL-Learner for the first time.


### PR DESCRIPTION
Hi DL-Learners,

this PR propose a docker image for running DL-Learner `cli` using Docker. The instruction how to do it are given on the [README](https://github.com/SmartDataAnalytics/DL-Learner/tree/feature/docker/docker) and the image has been linked with an [automated build on docker.hub](https://hub.docker.com/r/smartdataanalytics/dl-learner/).

Running `father` example gives this output : 
```sh
$ make run-example
docker run -it smartdataanalytics/dl-learner bin/cli examples/father.conf
DL-Learner command line interface
Initializing component 'ks' of type OWL File ...
... initialized component 'ks' in 1ms. Status: OK
Initializing component 'reasoner' of type closed world reasoner ...
OntologyID(OntologyIRI(<http://example.com/father>) VersionIRI(<null>))
Loaded reasoner: Pellet (com.clarkparsia.pellet.owlapiv3.PelletReasoner)
Materializing TBox...
...TBox materialised in 178 ms.
... initialized component 'reasoner' in 999ms. Status: OK
Initializing component 'lp' of type PosNegLPStandard ...
... initialized component 'lp' in 1ms. Status: OK
Initializing component 'alg' of type CELOE ...
... initialized component 'alg' in 21ms. Status: OK
Running algorithm instance "alg" (CELOE)
start class:Thing
more accurate (50.00%) class expression found after 47ms: Thing
more accurate (83.33%) class expression found after 105ms: male
more accurate (100.00%) class expression found after 156ms: male and (hasChild some Thing)
Algorithm terminated successfully (time: 1s 0ms, 1811 descriptions tested, 1059 nodes in the search tree).

number of retrievals: 1954
retrieval reasoning time: 42ms ( 0ms per retrieval)
number of instance checks: 89 (0 multiple)
instance check reasoning time: 0ms ( 0ms per instance check)
(complex) subsumption checks: 281 (0 multiple)
subsumption reasoning time: 70ms ( 0ms per subsumption check)
overall reasoning time: 113ms

solutions:
1: (male) and (hasChild some Thing) (pred. acc.: 100.00%, F-measure: 100.00%)
2: male and (hasChild some Thing) (pred. acc.: 100.00%, F-measure: 100.00%)
3: (not (female)) and (hasChild some Thing) (pred. acc.: 100.00%, F-measure: 100.00%)
4: male and (female or (hasChild some Thing)) (pred. acc.: 100.00%, F-measure: 100.00%)
5: (female or (hasChild some Thing)) and (not (female)) (pred. acc.: 100.00%, F-measure: 100.00%)
6: male and ((not (male)) or (hasChild some Thing)) (pred. acc.: 100.00%, F-measure: 100.00%)
7: male and (hasChild some (hasChild only (hasChild only male))) (pred. acc.: 100.00%, F-measure: 100.00%)
8: male and (hasChild some (male or (hasChild only male))) (pred. acc.: 100.00%, F-measure: 100.00%)
9: male and (hasChild some (male or (hasChild some Thing))) (pred. acc.: 100.00%, F-measure: 100.00%)
10: male and (hasChild some (male or (hasChild some male))) (pred. acc.: 100.00%, F-measure: 100.00%)
```
*Note : This is just a first prototype of runing DL-Learner on Docker, this can be improved by allowing user to specify their own configuration files and get the result back (if that is supported by DL-Learner already) outside of the docker.

Please, have a look and feel free to review and suggest changes.

Best regards,
Gezim