### PR TITLE
Fix manual.pdf build with recent tex distributions

### DIFF
--- a/interfaces/src/main/latex/manual/manual.tex
+++ b/interfaces/src/main/latex/manual/manual.tex
@@ -3,7 +3,7 @@
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[english]{babel}
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 \usepackage{amsmath,amssymb}
 \usepackage{verbatim}
 \usepackage{color,graphicx}


### PR DESCRIPTION
Hi,

[the SML Bench repository](https://github.com/SmartDataAnalytics/SML-Bench/blob/updates/learningsystems/dllearner/README.md) recommends building DL-Learner via `./buildRelease.sh`. However, this fails during compilation of `manual.pdf` on my machines, since the installed TeX distributions do not include the package `scrpage2`.

The package seems to be deprecated for quite some time (https://sourceforge.net/p/koma-script/wiki-de/Error_scrpage2/). Replacing it with `scrlayer-scrpage` fixes the problem for me. The resulting `manual.pdf`still looks reasonable as far as I can tell.